### PR TITLE
mongodb: extend configuration

### DIFF
--- a/core/mongodb.class.php
+++ b/core/mongodb.class.php
@@ -6,7 +6,23 @@ class Mongodb extends MongoDB\Client {
 
     public function __construct() {
         $this->database = UltimaPHP::$conf['mongodb']['database'];
-        $dsn            = 'mongodb://' . UltimaPHP::$conf['mongodb']['host'] . ':27017/' . $this->database;
+
+        $URI = UltimaPHP::$conf['mongodb']['URI'];
+        $username = UltimaPHP::$conf['mongodb']['username'];
+        $password = UltimaPHP::$conf['mongodb']['password'];
+        $host = UltimaPHP::$conf['mongodb']['host'];
+        $port = UltimaPHP::$conf['mongodb']['port'];
+
+        if (isset($URI)) {
+            $dsn = $URI . $this->database;
+        } else {
+            if (isset($username) && isset($password)) {
+                $dsn = 'mongodb://' . $username . ':' . $password . '@' . $host . ':' . $port . '/' . $this->database;
+            } else {
+                $dsn = 'mongodb://' . $host . ':' . $port . '/' . $this->database;
+            }
+        }
+
         parent::__construct($dsn, ['readPreference' => 'secondaryPreferred', 'keepAlive' => 1, 'connectTimeoutMS' => 30000, 'socketTimeoutMS' => 0], ['typeMap' => ['root' => 'array', 'document' => 'array', 'array' => 'array']]);
         $this->selectDatabase($this->database);
     }

--- a/core/server.php
+++ b/core/server.php
@@ -258,8 +258,12 @@ class UltimaPHP {
             $iniMessage = "Server save time not defined";
         } elseif (!isset(self::$conf['server']['client'])) {
             $iniMessage = "Server client not defined";
-        } elseif (!isset(self::$conf['mongodb']['host'])) {
-            $iniMessage = "Server mongodb host not defined";
+        } elseif (!isset(self::$conf['mongodb']['URI'])) {
+            if (!isset(self::$conf['mongodb']['host'])) {
+                $iniMessage = "Server mongodb host not defined";
+            } elseif (!isset(self::$conf['mongodb']['port'])) {
+                $iniMessage = "Server mongodb port not defined";
+            }
         } elseif (!isset(self::$conf['mongodb']['database'])) {
             $iniMessage = "Server mongodb database not defined";
         } elseif (!isset(self::$conf['accounts']['auto_create'])) {

--- a/core/server.php
+++ b/core/server.php
@@ -191,6 +191,7 @@ class UltimaPHP {
         self::setStatus(self::STATUS_DATABASE_CONNECTING);
         try {
             self::$db = new Mongodb();
+            self::setStatus(self::STATUS_DATABASE_CONNECTED);
         } catch (Exception $e) {
             self::setStatus(self::STATUS_DATABASE_CONNECTION_FAILED, array(
                 "\n" . $e->getMessage(),

--- a/ultimaphp.ini
+++ b/ultimaphp.ini
@@ -11,7 +11,11 @@ client=7.0.70.10,67.0.70.0
 commandPrefix=.
 
 [mongodb]
+URI=mongodb://ultimaphp:ultimaphp@127.0.0.1:27017/
+username=ultimaphp
+password=ultimaphp
 host=127.0.0.1
+port=27017
 database=ultimaphp
 
 [logs]


### PR DESCRIPTION
Hi,

I usually don't keep MongoDB running locally and use services like mLab (which is now a part of MongoDB Inc.), so having only `host` and `database` options is not enough to connect somewhere outside of your local machine OR an instance that was configured to run on a different port. 

I hope this helps.

Best,
G.