### PR TITLE
Fixing Line Separator Inconsistency

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Set the default behavior for line-endings, in case people don't have core.autocrlf set.
+#
+# Detailed explanation:
+# https://docs.github.com/en/github/getting-started-with-github/configuring-git-to-handle-line-endings#per-repository-settings
+#
+# Line endings under PSR-12 standard:
+# https://www.php-fig.org/psr/psr-12/#22-files
+*.php text=auto

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,4 @@
 #
 # Line endings under PSR-12 standard:
 # https://www.php-fig.org/psr/psr-12/#22-files
-*.php text=auto
+* text=auto


### PR DESCRIPTION
**Problem statement**:
When devs from different OS's (Windows, MAC, Linux) commit to the same code base, and they don't have `git config core.autocrlf` properly configured, they inadvertently change the line ending of the files they work on.
The result is having un-wanted changes or whole-file changes unrelated to the specific feature being developed.

The industry standard is to use Unix LF (linefeed) line ending only for PHP files:
https://www.php-fig.org/psr/psr-12/#22-files

**Solution**
Use `.gitattributes` text=auto configuration.
Detailed explanation: https://docs.github.com/en/github/getting-started-with-github/configuring-git-to-handle-line-endings#per-repository-settings

**Examples from other big open-source projects**
https://github.com/laravel/laravel/blob/8.x/.gitattributes
