### PR TITLE
Dev

### DIFF
--- a/core/account.class.php
+++ b/core/account.class.php
@@ -380,6 +380,7 @@ class Account {
 
         UltimaPHP::log("Client " . UltimaPHP::$socketClients[$this->client]['ip'] . " disconnected from the server");
         Sockets::out($this->client, $packet);
+        unset(UltimaPHP::$socketClients[$this->client]);
     }
 
     public function disconnectEvent($lot, $args) {
@@ -505,6 +506,7 @@ class Account {
             'statscap'        => UltimaPHP::$conf['accounts']['statscap'],
             'pets'            => 0,
             'maxpets'         => $maxPets,
+            'mounted'         => false,
             'resist_physical' => 0,
             'resist_fire'     => 0,
             'resist_cold'     => 0,

--- a/core/commands/color.command.php
+++ b/core/commands/color.command.php
@@ -30,7 +30,12 @@ class ColorCommand extends Command {
             return false;
         }
 
-        $instance = Map::getBySerial($target);
+        $instance = Map::getBySerial(strtoupper(dechex($target)));
+        if (empty($instance)) {
+            new SysmessageCommand($client, ["Sorry, something went wrong."]);
+            return false;
+        }
+
         $instance->color = intval($color);
         $instance->save();
 
@@ -38,7 +43,7 @@ class ColorCommand extends Command {
             $holder = Map::getBySerial($instance->holder);
 
             if ($holder->instanceType == UltimaPHP::INSTANCE_OBJECT) {
-                $holder->addItemToOpenedContainer($client, $instance);
+                $holder->addItemToOpenedContainer($instance, $client);
                 return true;
             }
         } else {

--- a/core/commands/color.command.php
+++ b/core/commands/color.command.php
@@ -36,7 +36,7 @@ class ColorCommand extends Command {
             return false;
         }
 
-        $instance->color = intval($color);
+        $instance->color = hexdec($color);
         $instance->save();
 
         if ($instance->holder !== null) {

--- a/core/packets/0x08.packet.php
+++ b/core/packets/0x08.packet.php
@@ -32,6 +32,6 @@ class packet_0x08 extends Packets {
         $z                = hexdec(Functions::fromChar8($data[9]));
         $grid_location    = $data[10];
         $conatiner_serial = Functions::implodeByte(11, 14, $data);
-        return UltimaPHP::$socketClients[$this->client]['account']->player->dropItem($item_serial, ['x' => $x, 'y' => $y, 'z' => $z], $grid_location, $conatiner_serial);
+        return UltimaPHP::$socketClients[$this->client]['account']->player->dropItem($item_serial, ['x' => $x, 'y' => $y, 'z' => $z], $conatiner_serial, $grid_location);
     }
 }

--- a/core/packets/0x80.packet.php
+++ b/core/packets/0x80.packet.php
@@ -60,6 +60,7 @@ class packet_0x80 extends Packets {
 		$account  = Functions::hexToChr($data, 1, 30, true);
 		$password = Functions::hexToChr($data, 31, 61, true);
 
+		// Account / Password validadion
 		$test = UltimaPHP::$db->collection("accounts")->find(['account' => $account])->toArray();
 		if (!empty($test[0]) && md5($password) != $test[0]['password']) {
 			// Send disconnect packet without account instance
@@ -71,7 +72,6 @@ class packet_0x80 extends Packets {
 			return false;
 		}
 
-		// Account / Password validadion TODO
 		UltimaPHP::$socketClients[$this->client]['account'] = array(
 			'account'  => $account,
 			'password' => md5($password),

--- a/core/packets/0x80.packet.php
+++ b/core/packets/0x80.packet.php
@@ -101,7 +101,7 @@ class packet_0x80 extends Packets {
 			$this->insertAccount($account, md5($password));
 			$this->receive($data);
 		} else {
-			UltimaPHP::$socketClients[$this->client]['account']->disconnect(RejectionReason::WRONG_PASSWORD);
+			UltimaPHP::$socketClients[$this->client]['account']->disconnect(RejectionReason::INVALID);
 		}
 		$this->insertClientVersion($account);
 

--- a/core/packets/0x80.packet.php
+++ b/core/packets/0x80.packet.php
@@ -64,7 +64,7 @@ class packet_0x80 extends Packets {
 		if (!empty($test[0]) && md5($password) != $test[0]['password']) {
 			// Send disconnect packet without account instance
 			$packet = new packet_0x82($this->client);
-	        $packet->setReason(RejectionReason::COMMUNICATION_PROBLEM);
+	        $packet->setReason(RejectionReason::WRONG_PASSWORD);
 	        $packet->send();
 	        
 			UltimaPHP::log("Account $account tried to login with wrong password.");

--- a/core/packets/0x80.packet.php
+++ b/core/packets/0x80.packet.php
@@ -60,7 +60,16 @@ class packet_0x80 extends Packets {
 		$account  = Functions::hexToChr($data, 1, 30, true);
 		$password = Functions::hexToChr($data, 31, 61, true);
 
-		$login = false;
+		$test = UltimaPHP::$db->collection("accounts")->find(['account' => $account])->toArray();
+		if (!empty($test[0]) && md5($password) != $test[0]['password']) {
+			// Send disconnect packet without account instance
+			$packet = new packet_0x82($this->client);
+	        $packet->setReason(RejectionReason::COMMUNICATION_PROBLEM);
+	        $packet->send();
+	        
+			UltimaPHP::log("Account $account tried to login with wrong password.");
+			return false;
+		}
 
 		// Account / Password validadion TODO
 		UltimaPHP::$socketClients[$this->client]['account'] = array(

--- a/core/packets/0xA9.packet.php
+++ b/core/packets/0xA9.packet.php
@@ -33,34 +33,31 @@ class packet_0xA9 extends Packets {
             return false;
         }
 
-        $this->addInt8($this->charCount);           
+        $this->addInt8($this->charCount);
 
-        for($i=0;$i<$this->charCount;$i++)
-        {            
+        for ($i = 0; $i < $this->charCount; $i++) {
             if ($i < count($this->chars)) {
-                $this->addText($this->chars[$i]['name'], 30);              
+                $this->addText($this->chars[$i]['name'], 30);
                 $this->addText("", 30);
             } else {
                 $this->addText("", 60);
             }
         }
 
-        $this->addInt8(dechex($this->citiesCount));        
+        $this->addInt8($this->citiesCount);
 
-        foreach ($this->cities as $key => $location) 
-        {
-            $this->addInt8(dechex($key+1));        
+        foreach ($this->cities as $key => $location) {
+            $this->addInt8($key);
             $this->addText($location['name'], 32);
             $this->addText($location['area'], 32);
-            $this->addInt32(dechex($location['position']['x']));
-            $this->addInt32(dechex($location['position']['y']));
-            $this->addInt32(dechex($location['position']['z']));
-            $this->addInt32(dechex($location['position']['map']));
-            $this->addUInt32(dechex($location['cliloc']));
+            $this->addInt32($location['position']['x']);
+            $this->addInt32($location['position']['y']);
+            $this->addInt32($location['position']['z']);
+            $this->addInt32($location['position']['map']);
+            $this->addInt32($location['cliloc']);
             $this->addInt32(0);
         }
 
-        
         $this->addInt32(dechex($this->flags));
         $this->addInt16($this->lastCharLost);
 
@@ -74,7 +71,7 @@ class packet_0xA9 extends Packets {
     }
 
     public function setCharCount($charCount) {
-        $this->charCount = (int)$charCount;
+        $this->charCount = (int) $charCount;
         return true;
     }
 
@@ -84,7 +81,7 @@ class packet_0xA9 extends Packets {
     }
 
     public function setCitiesCount($citiesCount) {
-        $this->citiesCount = (int)$citiesCount;
+        $this->citiesCount = (int) $citiesCount;
         return true;
     }
 
@@ -99,7 +96,7 @@ class packet_0xA9 extends Packets {
     }
 
     public function setLastCharLost($lastCharLost) {
-        $this->lastCharLost = (int)$lastCharLost;
+        $this->lastCharLost = (int) $lastCharLost;
         return true;
     }
 }

--- a/core/player.class.php
+++ b/core/player.class.php
@@ -1215,7 +1215,7 @@ class Player {
             $packet .= str_pad(dechex($this->damage_min), 4, "0", STR_PAD_LEFT);
             $packet .= str_pad(dechex($this->damage_max), 4, "0", STR_PAD_LEFT);
             $packet .= "00000000";
-            Sockets::out($this->client, $packet, $runInLot[0]);
+            Sockets::out($this->client, $packet, $runInLot);
         }
     }
 

--- a/core/player.class.php
+++ b/core/player.class.php
@@ -519,9 +519,16 @@ class Player {
         if (!in_array($instance->layer, [LayersDefs::HAND_ONE, LayersDefs::HAND_TWO, LayersDefs::SHOES, LayersDefs::PANTS, LayersDefs::SHIRT, LayersDefs::HELM, LayersDefs::GLOVES, LayersDefs::RING, LayersDefs::TALISMAN, LayersDefs::NECK, LayersDefs::WAIST, LayersDefs::INNER_TORSO, LayersDefs::BRACELET, LayersDefs::MIDDLE_TORSO, LayersDefs::EAR_RINGS, LayersDefs::ARMS, LayersDefs::CLOAK, LayersDefs::OUTER_TORSO, LayersDefs::OUTER_LEGS, LayersDefs::INNER_LEGS])) {
             // Sends the item to the player's backpack in case it doesn't fit the layer or the item isn't implemented yet
             if ($this->layers[LayersDefs::DRAGGING] == $serial) {
-                $this->dropItem($serial, false, $container, true);
+                // TODO: Add weight checks if the player has a backpack
+                if (empty($this->layers[LayersDefs::BACKPACK])) {
+                    $msg = "You don't know what to do with this item. You put it on the ground.";
+                    $this->dropItem($serial, $this->position, 'FFFFFFFF', false);
+                } else {
+                    $this->dropItem($serial, false, $this->layers[LayersDefs::BACKPACK], false);
+                    $msg = "You don't know what to do with this item. You put it on yours backpack.";
+                }
+                new SysmessageCommand($this->client, [$msg]);
             }
-            new SysmessageCommand($this->client, ["You don't know what to do with this item."]);
             return false;
         }
 

--- a/core/server.php
+++ b/core/server.php
@@ -285,8 +285,6 @@ class UltimaPHP {
             $iniMessage = "Server mongodb database not defined";
         } elseif (!isset(self::$conf['accounts']['auto_create'])) {
             $iniMessage = "Server accounts auto create not defined";
-        } elseif (!isset(self::$conf['accounts']['password_crypt'])) {
-            $iniMessage = "Server accounts password encrypt not defined";
         } elseif (!isset(self::$conf['accounts']['max_chars'])) {
             $iniMessage = "Server accounts maximum characters per account not defined";
         } elseif (!isset(self::$conf['accounts']['char_delete_time'])) {

--- a/core/sockets.core.php
+++ b/core/sockets.core.php
@@ -113,15 +113,18 @@ class Sockets {
                 $length = ($buffer ? count($buffer) : 0);
 
                 if ($buffer) {
+                    /**
+                     * 0xEF - First socket connection packet fix
+                     */
                     if ($socket['version'] === null) {
-                        if ($length == 20 && ($buffer[0] != 0xEF && $buffer[0] != "EF")) {
-                            array_unshift($buffer, "EF");
+                        // Single 0xEF packet receiving skipping
+                        if ($buffer[0] == "EF" && $length == 1) {
+                            continue;
                         }
 
-                        if (($buffer[0] == 0xEF || $buffer[0] == 0xEF) && $length == 21) {
-                            UltimaPHP::$socketClients[$client]['LastInput'] = $microtime;
-                            self::in($buffer, $client);
-                            continue;
+                        // When the second bytestrem received, adds the 0xEF to the packet start
+                        if (($length == 20 && ($buffer[0] != 0xEF && $buffer[0] != "EF")) ||  $length == 82){
+                            array_unshift($buffer, "EF");
                         }
                     }
 

--- a/ultimaphp.ini
+++ b/ultimaphp.ini
@@ -7,7 +7,7 @@ timezone=-3
 lang=pt_br
 max_players=20
 save_time=30*60
-client=7.0.80.0,67.0.74.0
+client=7.0.50.0,7.0.85.15,67.0.74.0
 commandPrefix=.
 socketTimeout=10
 

--- a/ultimaphp.ini
+++ b/ultimaphp.ini
@@ -26,7 +26,6 @@ debug=0
 
 [accounts]
 auto_create=0
-password_crypt=1
 max_chars=7
 char_delete_time=7*24*60*60
 login_tries=10


### PR DESCRIPTION
This is an attempt to fix the issue in the login process due to the weirdness of the packet 0xEF sent by the client.

**Issue**
> At the first socket connection communication, the client sends "weirdly" the packet 0xEF, causing a fault segmentation at the server.
> 
> As far as I've tested, it's something inside the client that makes it send randomly sometimes only 1 byte, sometimes the whole packet, sometimes a part of it.
> 
> This is now handled at the socket server, when the new connection has not sent yet the client version, the server assumes that we still need to receive the 0xEF with its 21 bytes (plus the 0x80 packet sometimes) and compose the packet with the next socket messages received.

It also fixes some other bugs I found out:

- Sending wrongly the starting location indexes dua a dechex() function.
- Socket cleanup after client disconnection.
- At the character creation, the "mount" index was missing, causing a lot of error logs.
- When the autoacc is activated, the server wasn't checking for its existence causing account duplication.
- Fixed some minor issues and removed unused .ini parameters.

It would be nice if someone could test it and see if it works.